### PR TITLE
build: upgrade vertx-http-proxy version, 4.3.5-SNAPSHOT cannot find

### DIFF
--- a/agate-gateway/pom.xml
+++ b/agate-gateway/pom.xml
@@ -103,7 +103,6 @@
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-http-proxy</artifactId>
-			<version>4.3.5-SNAPSHOT</version><!--$NO-MVN-MAN-VER$ -->
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
vertx-stack-depchain already contains vertx-http-proxy now, and 4.3.5-SNAPSHOT cannot be find